### PR TITLE
Removes create_keys variable

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_keys | Controls whether to create a set of keys | `bool` | `true` | no |
-| keys | Schema list of KMS Keys, consisting of alias, (OPTIONAL) description, (OPTIONAL) deletion\_window\_in\_days, (OPTIONAL) policy, (OPTIONAL) enable\_key\_rotation. The enable\_key\_rotation variable is a boolean. | `list(any)` | `[]` | no |
+| keys | Schema list of KMS Keys, consisting of alias, (OPTIONAL) description, (OPTIONAL) deletion\_window\_in\_days, (OPTIONAL) policy, (OPTIONAL) enable\_key\_rotation. The enable\_key\_rotation variable is a boolean. | `list(any)` | n/a | yes |
 
 ## Outputs
 

--- a/tests/create_keys/main.tf
+++ b/tests/create_keys/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "create_key" {
-  source      = "../../"
-  create_keys = true
-  keys        = local.keys
+  source = "../../"
+
+  keys = local.keys
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,4 @@
-variable "create_keys" {
-  description = "Controls whether to create a set of keys"
-  type        = bool
-  default     = true
-}
-
 variable "keys" {
   description = "Schema list of KMS Keys, consisting of alias, (OPTIONAL) description, (OPTIONAL) deletion_window_in_days, (OPTIONAL) policy, (OPTIONAL) enable_key_rotation. The enable_key_rotation variable is a boolean."
   type        = list(any)
-  default     = []
 }


### PR DESCRIPTION
Oops. This was supposed to go into the v1.0 release, but we missed actually removing the create_keys variable.